### PR TITLE
Event Browser

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -179,7 +179,7 @@ def node(node_name):
         reports=yield_or_stop(reports))
 
 
-@app.route('/events')
+@app.route('/events/')
 def events():
     events_class = eventcount_percentage(puppetdb, "containing-class")
     events_nodes = eventcount_percentage(puppetdb, "certname")

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -17,6 +17,7 @@ from pypuppetdb import connect
 
 from puppetboard.forms import QueryForm
 from puppetboard.utils import (
+    eventcount_percentage,
     get_or_abort, yield_or_stop,
     ten_reports, jsonprint
     )
@@ -176,6 +177,49 @@ def node(node_name):
         node=node,
         facts=yield_or_stop(facts),
         reports=yield_or_stop(reports))
+
+
+@app.route('/events')
+def events():
+    events_class = eventcount_percentage(puppetdb, "containing-class")
+    events_nodes = eventcount_percentage(puppetdb, "certname")
+    events_resources = eventcount_percentage(puppetdb, "resource")
+
+    return render_template('events.html',
+                           events_class = events_class,
+                           events_resources = events_resources,
+                           events_nodes = events_nodes)
+
+@app.route('/events/<event_sum>/<event_type>')
+def events_detail(event_sum, event_type):
+    events_class = eventcount_percentage(puppetdb, "containing-class")
+    events_nodes = eventcount_percentage(puppetdb, "certname")
+    events_resources = eventcount_percentage(puppetdb, "resource")
+    ev = puppetdb._query('events',query='["and",["=","latest-report?","true"],["=","status","%s"]]' % event_type)
+    events = {}
+
+    for e in ev:
+        if event_sum == 'class':
+           identifier = e['containing-class']
+        elif event_sum == 'resource':
+            identifier = '{0}[{1}]'.format(e['resource-type'], e['resource-title'])
+        elif event_sum == 'certname':
+            identifier = e['certname']
+        else:
+            identifier = None
+
+        if identifier not in events:
+            events[identifier] = [e]
+        else:
+            events[identifier].append(e)
+
+    return render_template('events.html',
+                           events = events,
+                           events_class = events_class,
+                           events_resources = events_resources,
+                           events_nodes = events_nodes,
+                           event_sum=event_sum,
+                           event_type=event_type)
 
 
 @app.route('/reports')

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -102,136 +102,94 @@ div[id^='message-event'] {
 .btn-lastreport {
   width:100px;
 }
-.panel {
-margin:0px
-}
-.panel.panel-primary {
-background-color: rgb(255, 255, 255);
-border: 1px solid transparent;
-border-radius: 4px;
-box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.05);
-border-color: rgb(44, 62, 80);
-margin-bottom: 10px;
-}
-.panel-heading {
-color: rgb(255, 255, 255);
-background-color: rgb(44, 62, 80);
-border-color: rgb(44, 62, 80);
-padding:0px;
-margin:0px;
-}
-.panel-title {
-margin:0;
-padding:3px;
-font-size:16px;
-line-height:140%;
-}
-.panel-title small {
-    float:right;
-    padding:4px;
-    font-size:12px;
-}
-.panel-body {
-padding:4px;
-overflow:hidden;
-display:none;
-}
-
-.param_label {
-    width:40%;
-    margin-right:10px;
-    display:block;
-    float:left;
-    text-align:right;
-    overflow:hidden;
-    color:#666;
-}
-.param_value {
-    width:48%;
-    float:left;
-}
-
 .statusbar {
-width:100%;
-background-color:#eee;
-height:15px;
-overflow:hidden;
+  width:100%;
+  background-color:#eee;
+  height:15px;
+  overflow:hidden;
 }
 .statusbar span {
-    width:40px;
-    height:100%;
-    display:block;
+  width:40px;
+  height:100%;
+  display:block;
 }
 .statusbar .failures {
-    background-color:#a00;
+  background-color:#a00;
 }
 .statusbar .changes {
-    background-color:#0a0;
+  background-color:#0a0;
 }
 .statusbar .noops {
-    background-color:#aaa;
+  background-color:#aaa;
+}
+.statusbar .skips {
+  background-color:#ccc;
 }
 .event-sidebar {
-    overflow:hidden;
-    display:block;
-    width:100%;
-    margin:0px;
-    padding:0px;
+  overflow:hidden;
+  display:block;
+  width:100%;
+  margin:0px;
+  padding:0px;
 }
 .event-sidebar a {
-    color:#000;
+  color:#000;
+  display:block;
 }
 .event-sidebar li {
-    margin-bottom:5px;
-    padding:7px;
-    padding-top:2px;
-    border:1px solid #fff;
-    opacity:0.7;
+  margin-bottom:5px;
+  padding:7px;
+  padding-top:2px;
+  border:1px solid #fff;
+  opacity:0.7;
 }
-.event-sidebar li:hover {
-    border:1px solid #aaa;
-    opacity:0.9;
+.event-sidebar li:hover,
+.event-sidebar li.active {
+  border:1px solid #aaa;
+  opacity:0.9;
 }
 .event-detail {
-    font-weight:900;
-    padding:10px;
-    margin-bottom:5px;
+  font-weight:900;
+  padding:10px;
+  margin-bottom:5px;
 }
 .event-list-detail {
-    padding:0px;
-    margin:0px;
-    padding-bottom:10px;
+  padding:0px;
+  margin:0px;
+  padding-bottom:10px;
 }
 .event-detail h5 {
-    font-weight:900;
-    margin:0px;
-    padding:5px;
+  font-weight:900;
+  margin:0px;
+  padding:5px;
 }
 .event-list-detail p {
-    background-color:#dfdfdf;
-    border:1px solid #aaa;
-    border-left:1px solid #aaa;
-    border-right:1px solid #aaa;
-    font-weight:100;
-    margin:0px;
-    padding:5px;
+  background-color:#dfdfdf;
+  border:1px solid #aaa;
+  border-left:1px solid #aaa;
+  border-right:1px solid #aaa;
+  font-weight:100;
+  margin:0px;
+  padding:5px;
 }
 .event-list-detail dl {
-    background-color:#eee;
-    margin:0px;
-    border-left:1px solid #aaa;
-    border-right:1px solid #aaa;
+  background-color:#eee;
+  margin:0px;
+  clear:both;
+  overflow:hidden;
 }
 .event-list-detail dt {
-    font-weight:100;
-    float:left;
-    text-align:right;
-    margin-right:10px;
-    width:150px;
-    padding:5px;
+  font-weight:100;
+  float:left;
+  text-align:right;
+  margin-right:10px;
+  width:150px;
+  padding:5px;
+  margin:0px;
 }
 .event-list-detail dd {
-    padding:5px;
-    margin:0;
-    border-bottom:1px solid #aaa;
+  padding:5px;
+  margin:0;
+  float:left;
+  width:441px;
 }

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -102,3 +102,136 @@ div[id^='message-event'] {
 .btn-lastreport {
   width:100px;
 }
+.panel {
+margin:0px
+}
+.panel.panel-primary {
+background-color: rgb(255, 255, 255);
+border: 1px solid transparent;
+border-radius: 4px;
+box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.05);
+border-color: rgb(44, 62, 80);
+margin-bottom: 10px;
+}
+.panel-heading {
+color: rgb(255, 255, 255);
+background-color: rgb(44, 62, 80);
+border-color: rgb(44, 62, 80);
+padding:0px;
+margin:0px;
+}
+.panel-title {
+margin:0;
+padding:3px;
+font-size:16px;
+line-height:140%;
+}
+.panel-title small {
+    float:right;
+    padding:4px;
+    font-size:12px;
+}
+.panel-body {
+padding:4px;
+overflow:hidden;
+display:none;
+}
+
+.param_label {
+    width:40%;
+    margin-right:10px;
+    display:block;
+    float:left;
+    text-align:right;
+    overflow:hidden;
+    color:#666;
+}
+.param_value {
+    width:48%;
+    float:left;
+}
+
+.statusbar {
+width:100%;
+background-color:#eee;
+height:15px;
+overflow:hidden;
+}
+.statusbar span {
+    width:40px;
+    height:100%;
+    display:block;
+}
+.statusbar .failures {
+    background-color:#a00;
+}
+.statusbar .changes {
+    background-color:#0a0;
+}
+.statusbar .noops {
+    background-color:#aaa;
+}
+.event-sidebar {
+    overflow:hidden;
+    display:block;
+    width:100%;
+    margin:0px;
+    padding:0px;
+}
+.event-sidebar a {
+    color:#000;
+}
+.event-sidebar li {
+    margin-bottom:5px;
+    padding:7px;
+    padding-top:2px;
+    border:1px solid #fff;
+    opacity:0.7;
+}
+.event-sidebar li:hover {
+    border:1px solid #aaa;
+    opacity:0.9;
+}
+.event-detail {
+    font-weight:900;
+    padding:10px;
+    margin-bottom:5px;
+}
+.event-list-detail {
+    padding:0px;
+    margin:0px;
+    padding-bottom:10px;
+}
+.event-detail h5 {
+    font-weight:900;
+    margin:0px;
+    padding:5px;
+}
+.event-list-detail p {
+    background-color:#dfdfdf;
+    border:1px solid #aaa;
+    border-left:1px solid #aaa;
+    border-right:1px solid #aaa;
+    font-weight:100;
+    margin:0px;
+    padding:5px;
+}
+.event-list-detail dl {
+    background-color:#eee;
+    margin:0px;
+    border-left:1px solid #aaa;
+    border-right:1px solid #aaa;
+}
+.event-list-detail dt {
+    font-weight:100;
+    float:left;
+    text-align:right;
+    margin-right:10px;
+    width:150px;
+    padding:5px;
+}
+.event-list-detail dd {
+    padding:5px;
+    margin:0;
+    border-bottom:1px solid #aaa;
+}

--- a/puppetboard/static/js/lists.js
+++ b/puppetboard/static/js/lists.js
@@ -25,8 +25,8 @@
   });
 
   $('.event-list-detail dl').hide();
-  $('.event-list-detail').click(function() {
-    $(this).find('dl').slideToggle();
+  $('.event-list-detail p').click(function() {
+    $(this).parent().find('dl').slideToggle();
   });
 
 }).call(this);

--- a/puppetboard/static/js/lists.js
+++ b/puppetboard/static/js/lists.js
@@ -24,4 +24,9 @@
     }
   });
 
+  $('.event-list-detail dl').hide();
+  $('.event-list-detail').click(function() {
+    $(this).find('dl').slideToggle();
+  });
+
 }).call(this);

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -146,3 +146,37 @@
   </tbody>
 </table>
 {%- endmacro %}
+
+{% macro eventbars(summary,events) -%}
+<ul class="event-sidebar">
+    <li>
+    <a href="/events/{{summary}}/failure">
+        {{ events['failures'] }} 
+        failures <div class="statusbar">
+            <span class="failures" style="width: {{events['failures_per']}}%;"> </span></div></li>
+    </a>
+    <li>
+    <a href="/events/{{summary}}/success">
+        {{ events['successes'] }} 
+        successes <div class="statusbar">
+            <span class="changes" style="width: {{events['successes_per']}}%;"> </span></div>
+    </a>
+    </li>
+    <li>
+    <a href="/events/{{summary}}/noop">
+        {{ events['noops'] }} 
+        noops <div class="statusbar">
+            <span class="noops" style="width: {{events['noops_per']}}%;"> </span></div>
+    </a>
+    </li>
+    <li>
+    <a href="/events/{{summary}}/skipped">
+        {{ events['skips'] }} 
+        skips <div class="statusbar">
+            <span class="noops" style="width: {{events['skips_per']}}%;"> </span></div>
+    </a>
+    </li>
+</ul>
+{%- endmacro %}
+
+

--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -147,33 +147,33 @@
 </table>
 {%- endmacro %}
 
-{% macro eventbars(summary,events) -%}
+{% macro eventbars(event_sum,event_type,summary,events) -%}
 <ul class="event-sidebar">
-    <li>
+    <li{% if event_sum == summary and event_type == 'failure' %} class="active"{% endif%}>
     <a href="/events/{{summary}}/failure">
         {{ events['failures'] }} 
         failures <div class="statusbar">
             <span class="failures" style="width: {{events['failures_per']}}%;"> </span></div></li>
     </a>
-    <li>
+    <li{% if event_sum == summary and event_type == 'success' %} class="active"{% endif%}>
     <a href="/events/{{summary}}/success">
         {{ events['successes'] }} 
         successes <div class="statusbar">
             <span class="changes" style="width: {{events['successes_per']}}%;"> </span></div>
     </a>
     </li>
-    <li>
+    <li{% if event_sum == summary and event_type == 'noop' %} class="active"{% endif%}>
     <a href="/events/{{summary}}/noop">
         {{ events['noops'] }} 
         noops <div class="statusbar">
             <span class="noops" style="width: {{events['noops_per']}}%;"> </span></div>
     </a>
     </li>
-    <li>
+    <li{% if event_sum == summary and event_type == 'skipped' %} class="active"{% endif%}>
     <a href="/events/{{summary}}/skipped">
         {{ events['skips'] }} 
         skips <div class="statusbar">
-            <span class="noops" style="width: {{events['skips_per']}}%;"> </span></div>
+            <span class="skips" style="width: {{events['skips_per']}}%;"> </span></div>
     </a>
     </li>
 </ul>

--- a/puppetboard/templates/events.html
+++ b/puppetboard/templates/events.html
@@ -1,0 +1,39 @@
+{% extends 'layout.html' %}
+{% import '_macros.html' as macros %}
+{% block row_fluid %}
+<div class="container" style="margin-bottom:55px;">
+
+  <div class="row">
+    <div class="span12">
+      <div class="span4 stat">
+          <h4>Classes</h4>
+          {{ macros.eventbars('class',events_class) }}
+          <h4>Nodes</h4>
+          {{ macros.eventbars('certname',events_nodes) }}
+          <h4>Resources</h4>
+          {{ macros.eventbars('resource',events_resources) }}
+      </div>
+      <div class="span8 stat">
+          <h4>{{event_sum}} with {{event_type}}</h4>
+          {% for id in events %}
+                <div class="event-detail">
+                    <h5>{{id}}</h3>
+                    {% for e in events[id] %}
+                    <div class="event-list-detail">
+                    <p>
+                        {% if id != e['certname'] %}{{e['certname']}}{% endif %}
+                        {% if event_sum != 'resource' %}
+                            {{ e['resource-type'] }}[{{e['resource-title']}}]
+                         {% endif %}</p>
+                        <dl>{% for key in e%}
+                            <dt>{{key}}</dt><dd>{{e[key] }}</dd>{% endfor%}
+                        </dl>
+                    </div>
+                    {% endfor %}
+          </div>
+          {% endfor %}
+     </div>
+    </div>
+  </div>
+</div>
+{% endblock row_fluid %}

--- a/puppetboard/templates/events.html
+++ b/puppetboard/templates/events.html
@@ -7,26 +7,43 @@
     <div class="span12">
       <div class="span4 stat">
           <h4>Classes</h4>
-          {{ macros.eventbars('class',events_class) }}
+          {{ macros.eventbars(event_sum,event_type,'class',events_class) }}
           <h4>Nodes</h4>
-          {{ macros.eventbars('certname',events_nodes) }}
+          {{ macros.eventbars(event_sum,event_type,'certname',events_nodes) }}
           <h4>Resources</h4>
-          {{ macros.eventbars('resource',events_resources) }}
+          {{ macros.eventbars(event_sum,event_type,'resource',events_resources) }}
       </div>
       <div class="span8 stat">
-          <h4>{{event_sum}} with {{event_type}}</h4>
+          {% if event_sum and event_type %}
+             <h4>{{event_sum}} with {{event_type}}</h4>
+          {% endif %}
           {% for id in events %}
                 <div class="event-detail">
-                    <h5>{{id}}</h3>
+                    <h5>
+                        {% if event_sum == 'certname' %}
+                            <a href="{{url_for('node', node_name=id)}}">{{ id }}</a>
+                        {% else %}
+                            {{ id }}
+                        {% endif %}
+                    </h5>
                     {% for e in events[id] %}
                     <div class="event-list-detail">
                     <p>
-                        {% if id != e['certname'] %}{{e['certname']}}{% endif %}
+                        {% if event_sum != 'certname' %}
+                        <a href="{{url_for('node', node_name=e['certname'])}}">{{e['certname']}}</a>
+                        {% endif %}
                         {% if event_sum != 'resource' %}
                             {{ e['resource-type'] }}[{{e['resource-title']}}]
                          {% endif %}</p>
                         <dl>{% for key in e%}
-                            <dt>{{key}}</dt><dd>{{e[key] }}</dd>{% endfor%}
+                            <dt>{{key}}</dt>
+                            <dd>
+                                {% if e[key] is iterable and e[key] is not string %}
+                                    {% for i in e[key] %}{{i}} {{e[key][i]}}<br />{% endfor%}
+                                {% else %}
+                                    {{e[key] }}
+                                {% endif %}
+                                </dd>{% endfor%}
                         </dl>
                     </div>
                     {% endfor %}

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -25,6 +25,7 @@
               ('nodes', 'Nodes'),
               ('facts', 'Facts'),
               ('reports', 'Reports'),
+              ('events', 'Events'),
               ('metrics', 'Metrics'),
               ('query', 'Query'),
                 ] %}

--- a/puppetboard/utils.py
+++ b/puppetboard/utils.py
@@ -53,3 +53,14 @@ def yield_or_stop(generator):
             raise
         except (EmptyResponseError, ConnectionError, HTTPError):
             raise StopIteration
+
+def eventcount_percentage(puppetdb, summarize_by):
+    events = puppetdb._query('aggregate-event-counts',
+                             query="[\"=\",\"latest-report?\",\"true\"]",
+                             summarize_by=summarize_by)
+    events['failures_per'] = float(events['failures']) / float(events['total']) * 100
+    events['skips_per'] = float(events['skips']) / float(events['total']) * 100
+    events['successes_per'] = float(events['successes']) / float(events['total']) * 100
+    events['noops_per'] = float(events['noops']) / float(events['total']) * 100
+    return events
+


### PR DESCRIPTION
These commits bring a simple event browser into puppetboard, similar to the event inspector in Puppet Enterprise. 

You can browse events of the latest reports grouped by nodes, containing-class or resource and get details on every event.

![eventbrowser](https://f.cloud.github.com/assets/3404133/2050011/bc26c6f8-8a6b-11e3-862e-47d909e679b8.png)
