### PR TITLE
Accept the configuration_version as alternative in the report view.

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -226,11 +226,15 @@ def report_latest(node_name):
 def report(node, report_id):
     """Displays a single report including all the events associated with that
     report and their status.
+
+    The report_id may be the puppetdb's report hash or the 
+    configuration_version. This allows for better integration
+    into puppet-hipchat.
     """
     reports = puppetdb.reports('["=", "certname", "{0}"]'.format(node))
 
     for report in reports:
-        if report.hash_ == report_id:
+        if report.hash_ == report_id or report.version == report_id:
             events = puppetdb.events('["=", "report", "{0}"]'.format(
                 report.hash_))
             return render_template(


### PR DESCRIPTION
[puppet-hipchat](https://github.com/jamtur01/puppet-hipchat) has this very helpful feature where the puppet runs that are logged in the chat are posted with a link to the report.

Unfortunately, for now only the '/latest' report can be linked as the report hash is not available in the puppet report format.

I thought the easiest way to change this is to optionally accept the configuration_version as the `<report_id>`. It's a tiny change really, but it would help solve this problem:

https://github.com/jamtur01/puppet-hipchat/pull/23#discussion-diff-10535251

We'll then end up with this:
![screenshot of google chrome 10-09-14 16 41 34](https://cloud.githubusercontent.com/assets/273163/4219287/a486c9d0-38f8-11e4-9614-21f251f4def5.png)
