### PR TITLE
Adds custom facts to enumerate in nodes list

### DIFF
--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -23,3 +23,4 @@ GRAPH_FACTS = ['architecture',
                'osfamily',
                'puppetversion',
                'processorcount']
+NODES_FACTS = []

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -66,6 +66,9 @@
           <tr>
             <th class="five wide">Status</th>
             <th class="ten wide">Hostname</th>
+            {% for nodes_fact in config.NODES_FACTS -%}
+            <th>{{nodes_fact}}</th>
+            {% endfor -%}
             <th class="one wide"></th>
           </tr>
         </thead>
@@ -97,6 +100,13 @@
             <td>
               <a href="{{url_for('node', node_name=node.name)}}">{{ node.name }}</a>
             </td>
+            {% for node_fact in config.NODES_FACTS -%}
+            {% if node.fact(node_fact) -%}
+            <td>{{node.fact(node_fact).value}}</td>
+            {% else -%}
+            <td></td>
+            {% endif -%}
+            {% endfor -%}
             <td>
               <a title="Latest Report" href="{{url_for('report_latest', node_name=node.name)}}">
                 <i class="large tasks darkblue icon"></i>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -8,6 +8,9 @@
     <tr>
       <th>Status</th>
       <th>Hostname</th>
+      {% for nodes_fact in config.NODES_FACTS -%}
+      <th>{{nodes_fact}}</th>
+      {% endfor -%}
       <th>Catalog</th>
       <th>Report</th>
       <th>&nbsp;</th>
@@ -38,6 +41,13 @@
           {% endif %}
       </td>
       <td><a href="{{url_for('node', node_name=node.name)}}">{{node.name}}</a></td>
+      {% for node_fact in config.NODES_FACTS -%}
+        {% if node.fact(node_fact) -%}
+          <td>{{node.fact(node_fact).value}}</td>
+        {% else -%}
+          <td></td>
+        {% endif -%}
+      {% endfor -%}
       <td rel="utctimestamp">{{node.catalog_timestamp}}</td>
       <td>
         {% if node.report_timestamp %}


### PR DESCRIPTION
Enumerates a specific fact to show during the node list, which is
configurable as NODES_FACTS in the configuration.

I've added a default entry which is empty, and some detection around if
a fact doesn't exist on a value (which should just print none).