### PR TITLE
Add requires section to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [bdist_rpm]
 build_requires = python-setuptools
+requires = python-flask
+           python-flask-wtf
+           python-pypuppetdb


### PR DESCRIPTION
This is so "yum install puppetboard" also pulls in all the required python module RPMs automatically.