### PR TITLE
Fix proxy_pass line in nginx+gunicorn example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -490,7 +490,7 @@ differ too much. As we can't use ``uwsgi_pass`` with gunicorn, the nginx configu
             proxy_set_header X-Scheme $scheme;
             proxy_connect_timeout 10;
             proxy_read_timeout 10;
-            proxy_pass 127.0.0.1:9090;
+            proxy_pass http://127.0.0.1:9090;
         }
     }
 


### PR DESCRIPTION
The example was missing the protocol part of the backend server URL
('http://'). This causes nginx to complain of a "malformed URL".