### PR TITLE
Repaired sorting of date columns

### DIFF
--- a/puppetboard/static/coffeescript/tables.coffee
+++ b/puppetboard/static/coffeescript/tables.coffee
@@ -1,21 +1,38 @@
 $ = jQuery
 $ ->
+
+$.tablesorter.addParser(
+  id: 'timestamp'
+
+  # Return false so this parser is not auto detected
+  is: (s) ->
+    false
+
+  # Normalize the timestamp to epoch for sorting
+  format: (s) ->
+    moment.utc(s).unix()
+
+  # The return value of our normalization function is an integer
+  type: 'numeric'
+)
+
 $('.nodes').tablesorter(
-    headers:
-        4:
-            sorter: false
-    sortList: [[1,0]]
+  headers:
+    2: sorter: 'timestamp'
+    3: sorter: 'timestamp'
+    4: sorter: false
+  sortList: [[1,0]]
 )
 
 $('.facts').tablesorter(
-    sortList: [[0,0]]
+  sortList: [[0,0]]
 )
 
 $('.dashboard').tablesorter(
-    headers:
-        3:
-            sorter: false
-    sortList: [[0, 1]]
+  headers:
+    2: sorter: 'timestamp'
+    3: sorter: false
+  sortList: [[0, 1]]
 )
 
 $('input.filter-table').parent('div').removeClass('hide')

--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -6,8 +6,25 @@
 
   $(function() {});
 
+  $.tablesorter.addParser({
+    id: 'timestamp',
+    is: function(s) {
+      return false;
+    },
+    format: function(s) {
+      return moment.utc(s).unix();
+    },
+    type: 'numeric'
+  });
+
   $('.nodes').tablesorter({
     headers: {
+      2: {
+        sorter: 'timestamp'
+      },
+      3: {
+        sorter: 'timestamp'
+      },
       4: {
         sorter: false
       }
@@ -21,6 +38,9 @@
 
   $('.dashboard').tablesorter({
     headers: {
+      2: {
+        sorter: 'timestamp'
+      },
       3: {
         sorter: false
       }


### PR DESCRIPTION
Hello, this pull request addresses issue #6 and also incorporates some touch-ups to the syntax of the coffee file to be consistent throughout (2-space indentation primarily).

This may cause a little trouble when merged with my other pull request #137, happy to help if it causes any drama, you'll need to update the dashboard tablesorter to use my new `timestamp` sorter for the report column which I added :smile: 

Cheers
Fotis