### PR TITLE
Patch _macros.html for the latest cleanups

### DIFF
--- a/puppetboard/templates/_macros.html
+++ b/puppetboard/templates/_macros.html
@@ -108,7 +108,7 @@
     <td rel="utctimestamp">{{report.start}}</td>
       <td>{{report.run_time}}</td>
 
-      <td><a href="{{url_for('report', node=nodename, report_id=report.hash_)}}">{{rep_hash}}</a></td>
+      <td><a href="{{url_for('report', node_name=nodename, report_id=report.hash_)}}">{{rep_hash}}</a></td>
       {% if show_conf_col %}
         <td>{{report.version}}</td>
       {% endif %}


### PR DESCRIPTION
97bbe96 renamed the keyword arguments for report(node_name, report_id) but _macros.html wasn't updated