### PR TITLE
puppetboard: Adding Catalog Viewer

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -403,3 +403,13 @@ def metric(metric):
         'metric.html',
         name=name,
         metric=sorted(metric.items()))
+
+@app.route('/catalog/<node_name>')
+def catalog_node(node_name):
+    """Fetches from PuppetDB the compiled catalog of a given node."""
+    if app.config['ENABLE_CATALOG']:
+        catalog = puppetdb.catalog(node=node_name)
+        return render_template('catalog.html', catalog=catalog)
+    else:
+        log.warn('Access to catalog interface disabled by administrator')
+        abort(403)

--- a/puppetboard/default_settings.py
+++ b/puppetboard/default_settings.py
@@ -16,6 +16,7 @@ LOCALISE_TIMESTAMP = True
 LOGLEVEL = 'info'
 REPORTS_COUNT = 10
 OFFLINE_MODE = False
+ENABLE_CATALOG = False
 GRAPH_FACTS = ['architecture',
                'domain',
                'lsbcodename',

--- a/puppetboard/static/coffeescript/tables.coffee
+++ b/puppetboard/static/coffeescript/tables.coffee
@@ -35,6 +35,10 @@ $('.dashboard').tablesorter(
   sortList: [[0, 1]]
 )
 
+$('.catalog').tablesorter(
+    sortList: [[0, 0]]
+)
+
 $('input.filter-table').parent('div').removeClass('hide')
 $("input.filter-table").on "keyup", (e) ->
   rex = new RegExp($(this).val(), "i")

--- a/puppetboard/static/js/tables.js
+++ b/puppetboard/static/js/tables.js
@@ -52,6 +52,11 @@
     sortList: [[0, 1]]
   });
 
+
+  $('.catalog').tablesorter({
+    sortList: [[0, 0]]
+  })
+
   $('input.filter-table').parent('div').removeClass('hide');
 
   $("input.filter-table").on("keyup", function(e) {

--- a/puppetboard/templates/catalog.html
+++ b/puppetboard/templates/catalog.html
@@ -1,0 +1,61 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="ui fluid icon input hide" style="margin-bottom:20px">
+  <input autofocus="autofocus" class="filter-table" placeholder="Type here to filter...">
+</div>
+<h1>Summary</h1>
+<table class='ui basic table'>
+  <thead>
+    <tr>
+      <th>Hostname</th>
+      <th>Version</th>
+      <th>Transaction UUID</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="{{url_for('node', node_name=catalog.node)}}">{{catalog.node}}</a></td>
+      <td>{{catalog.version}}</td>
+      <td>{{catalog.transaction_uuid}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h1>Resources</h1>
+<table class='ui basic table compact catalog'>
+  <thead>
+    <tr>
+      <th>Resource</th>
+      <th>Location</th>
+    </tr>
+  </thead>
+  <tbody class='searchable'>
+    {% for resource in catalog.get_resources() %}
+    <tr>
+      <td>{{resource.type_}}[{{resource.name}}]</td>
+      <td>{{resource.sourcefile}}:{{resource.sourceline}}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h1>Edges</h1>
+<table class="ui basic table compact catalog">
+  <thead>
+    <tr>
+      <th>Source</th>
+      <th>Relationship</th>
+      <th>Target</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for edge in catalog.get_edges() %}
+    <tr>
+      <td>{{edge.source}}</td>
+      <td>{{edge.relationship}}</td>
+      <td>{{edge.target}}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock content %}

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -39,7 +39,7 @@
           {% endif %}
       </td>
       <td><a href="{{url_for('node', node_name=node.name)}}">{{node.name}}</a></td>
-      <td rel="utctimestamp">{{node.catalog_timestamp}}</td>
+      <td><a rel="utctimestamp" href="{{url_for('catalog_node', node_name=node.name)}}">{{node.catalog_timestamp}}</a></td>
       <td>
         {% if node.report_timestamp %}
         <a href="{{url_for('report_latest', node_name=node.name)}}" rel='utctimestamp'>{{ node.report_timestamp }}</a>


### PR DESCRIPTION
This makes use of the available catalog endpoints in pypuppetdb and PuppetDB
and displays to administrators the last compiled catalog for a node,
if the variable ENABLE_CATALOG is True (defaults to False)

This is a re-work of https://github.com/puppet-community/puppetboard/pull/93 and https://github.com/puppet-community/puppetboard/pull/115