### PR TITLE
puppetboard/app.py: Optimizing the inventory page

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -201,9 +201,6 @@ def inventory():
                         # facts indexed by node name
     nodelist   = set()  # a set of node names
 
-    # get all the facts from PuppetDB
-    facts = puppetdb.facts()
-
     # load the list of items/facts we want in our inventory
     try:
         inv_facts = app.config['INVENTORY_FACTS']
@@ -219,6 +216,13 @@ def inventory():
     for description,name in inv_facts:
         fact_desc.append(description)
         fact_names.append(name)
+
+    query = '["or", {0}]'.format(
+        ', '.join('["=", "name", "{0}"]'.format(name)
+            for name in fact_names))
+
+    # get all the facts from PuppetDB
+    facts = puppetdb.facts(query=query)
 
     # convert the json in easy to access data structure
     for fact in facts:


### PR DESCRIPTION
Instead of querying the ```/facts``` endpoint in PuppetDB for every fact that it knows about only
query it for the names that we want. The result is a
much smaller result set that is more noticeable on environments with
large numbers of nodes and/or facts.

On one environment with > 2500 fact-names and 35 nodes a curl test
to the facts endpoint without any query string returned in ~3.5 seconds.
Ran another curl test to the facts endpoint with the query string that
the code in this commit creates, the command finished in ~0.040 seconds.

This is an update for the functionality that was introduced in https://github.com/puppet-community/puppetboard/pull/135