### PR TITLE
Make Puppetboard work with the PuppetDB V4 api

### DIFF
--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -37,7 +37,6 @@ app.secret_key = app.config['SECRET_KEY']
 app.jinja_env.filters['jsonprint'] = jsonprint
 
 puppetdb = connect(
-    api_version=3,
     host=app.config['PUPPETDB_HOST'],
     port=app.config['PUPPETDB_PORT'],
     ssl_verify=app.config['PUPPETDB_SSL_VERIFY'],
@@ -102,7 +101,7 @@ def index():
     """
     # TODO: Would be great if we could parallelize this somehow, doing these
     # requests in sequence is rather pointless.
-    prefix = 'com.puppetlabs.puppetdb.query.population'
+    prefix = 'puppetlabs.puppetdb.query.population'
     num_nodes = get_or_abort(
         puppetdb.metric,
         "{0}{1}".format(prefix, ':type=default,name=num-nodes'))
@@ -272,7 +271,7 @@ def reports_node(node_name):
     a table displaying those reports."""
     reports = limit_reports(
         yield_or_stop(
-            puppetdb.reports('["=", "certname", "{0}"]'.format(node_name))),
+            puppetdb.reports(query='["=", "certname", "{0}"]'.format(node_name))),
         app.config['REPORTS_COUNT'])
     return render_template(
         'reports_node.html',
@@ -307,11 +306,11 @@ def report(node_name, report_id):
     configuration_version. This allows for better integration
     into puppet-hipchat.
     """
-    reports = puppetdb.reports('["=", "certname", "{0}"]'.format(node_name))
+    reports = puppetdb.reports(query='["=", "certname", "{0}"]'.format(node_name))
 
     for report in reports:
         if report.hash_ == report_id or report.version == report_id:
-            events = puppetdb.events('["=", "report", "{0}"]'.format(
+            events = puppetdb.events(query='["=", "report", "{0}"]'.format(
                 report.hash_))
             return render_template(
                 'report.html',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ MarkupSafe==0.19
 WTForms==1.0.5
 Werkzeug==0.9.4
 itsdangerous==0.23
-pypuppetdb==0.1.1
+git+https://github.com/raphink/pypuppetdb@v4-api#egg=pypuppetdb-0.1.0
 requests==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ MarkupSafe==0.19
 WTForms==1.0.5
 Werkzeug==0.9.4
 itsdangerous==0.23
-git+https://github.com/raphink/pypuppetdb@v4-api#egg=pypuppetdb-0.1.0
+pypuppetdb==0.2.0
 requests==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.9.4, <= 0.9.5",
         "WTForms < 2.0",
-        "pypuppetdb >= 0.1.0, < 0.2.0",
+    dependency_links=[
+        "git+https://github.com/raphink/pypuppetdb@v4-api#egg=pypuppetdb",
         ],
     keywords="puppet puppetdb puppetboard",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ setup(
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.9.4, <= 0.9.5",
         "WTForms < 2.0",
-    dependency_links=[
-        "git+https://github.com/raphink/pypuppetdb@v4-api#egg=pypuppetdb",
+        "pypuppetdb >= 0.2.0, < 0.3.0",
         ],
     keywords="puppet puppetdb puppetboard",
     classifiers=[


### PR DESCRIPTION
This PR adapts puppetboard to work with https://github.com/puppet-community/pypuppetdb/pull/58

All the features seemed to work fine with that.