### PR TITLE
puppetboard: Version bump to 0.0.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,26 @@ Changelog
 
 This is the changelog for Puppetboard.
 
+0.0.5
+=====
+
+* Now requires WTForms versions less than 2.0
+* Adding a Flask development server in ``dev.py``.
+* Adding CSRF protection VIA the flask_wtf CsrfProtect object.
+* Allowing users to configure the report limit on pages where reports are
+  listed with the LIMIT_REPORTS configuration option.
+* Adding an inventory page to users to be able to see all available nodes
+  and a configure lists of facts to display VIA the INVENTORY_FACTS
+  configuration option.
+* Adding a page to view a node's catalog information if enabled, disabled
+  by default. Can be changed with the ENABLE_CATALOG configuration attribute.
+* New configuration option GRAPH_FACTS allows the user to choose which graphs
+  will generate pie on the fact pages.
+* Replacing Chart.js with c3.js and d3.js.
+* Adding Semantic UI 0.16.1 and removing unused bootstrap styles.
+* Adding an OFFLINE_MODE configuration option to load local assets or from a
+  CDN service. This is useful in environments without internet access.
+
 0.0.4
 =====
 

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -39,7 +39,7 @@
       <a {% if endpoint == request.endpoint %} class="active item" {% else %} class="item" {% endif %}
         href="{{ url_for(endpoint) }}">{{ caption }}</a>
       {%- endfor %}
-      <div class="item" style="float:right"><a href="https://github.com/puppet-community/puppetboard" target="_blank">v0.0.4</a></div>
+      <div class="item" style="float:right"><a href="https://github.com/puppet-community/puppetboard" target="_blank">v0.0.5</a></div>
     </nav>
     <div class="ui grid padding-bottom">
       <div class="one wide column"></div>

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.9.4, <= 0.9.5",
         "WTForms < 2.0",
-        "pypuppetdb < 0.2.0",
+        "pypuppetdb >= 0.1.0, < 0.2.0",
         ],
     keywords="puppet puppetdb puppetboard",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 
 with codecs.open('README.rst', encoding='utf-8') as f:
     README = f.read()
@@ -32,7 +32,7 @@ setup(
         "Flask >= 0.10.1",
         "Flask-WTF >= 0.9.4, <= 0.9.5",
         "WTForms < 2.0",
-        "pypuppetdb >= 0.1.0",
+        "pypuppetdb < 0.2.0",
         ],
     keywords="puppet puppetdb puppetboard",
     classifiers=[


### PR DESCRIPTION
In preparation for the release of 0.1.0, with PuppetDB 3.x support, bumping the version from 0.0.4 to 0.0.5.

The most significant change is the setup now requires pypuppetdb < 0.2.0 instead of >= 0.1.0