### PR TITLE
Make "skips" color consistent

### DIFF
--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -75,6 +75,23 @@ th.tablesorter-headerDesc::after {
   color: #FFF;
 }
 
+.ui.menu.yellow {
+  background-color: #FFFF64;
+}
+
+.ui.yellow.header, i.yellow {
+  color: #FFFF64;
+}
+
+.ui.labels .yellow.label::before, .ui.yellow.labels .label::before, .ui.yellow.label::before {
+  background-color: #FFFF64;
+}
+
+.ui.yellow.labels .label, .ui.yellow.label {
+  background-color: #FFFF64;
+  border-color: #FFFF64;
+}
+
 #scroll-btn-top {
   position: fixed;
   overflow: hidden;

--- a/puppetboard/static/css/puppetboard.css
+++ b/puppetboard/static/css/puppetboard.css
@@ -76,20 +76,20 @@ th.tablesorter-headerDesc::after {
 }
 
 .ui.menu.yellow {
-  background-color: #FFFF64;
+  background-color: #F0E965;
 }
 
 .ui.yellow.header, i.yellow {
-  color: #FFFF64;
+  color: #F0E965;
 }
 
 .ui.labels .yellow.label::before, .ui.yellow.labels .label::before, .ui.yellow.label::before {
-  background-color: #FFFF64;
+  background-color: #F0E965;
 }
 
 .ui.yellow.labels .label, .ui.yellow.label {
-  background-color: #FFFF64;
-  border-color: #FFFF64;
+  background-color: #F0E965;
+  border-color: #F0E965;
 }
 
 #scroll-btn-top {

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -93,7 +93,7 @@
                 {% else %}
                    {% if node.events['failures'] %}<span class="ui small count label red">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
                    {% if node.events['successes'] %}<span class="ui small count label green">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-                   {% if node.events['skips'] %}<span class="ui small count label orange">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+                   {% if node.events['skips'] %}<span class="ui small count label black">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
                 {% endif %}
             </td>
             <td>

--- a/puppetboard/templates/index.html
+++ b/puppetboard/templates/index.html
@@ -93,7 +93,7 @@
                 {% else %}
                    {% if node.events['failures'] %}<span class="ui small count label red">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
                    {% if node.events['successes'] %}<span class="ui small count label green">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
-                   {% if node.events['skips'] %}<span class="ui small count label black">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+                   {% if node.events['skips'] %}<span class="ui small count label yellow">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
                 {% endif %}
             </td>
             <td>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -35,7 +35,7 @@
           {% else %}
           <span>{% if node.events['failures'] %}<span class="ui small count label red">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
             {% if node.events['successes'] %}<span class="ui small count label green">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}</span>
-            {% if node.events['skips'] %}<span class="ui small count label black">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+            {% if node.events['skips'] %}<span class="ui small count label yellow">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
           {% endif %}
       </td>
       <td><a href="{{url_for('node', node_name=node.name)}}">{{node.name}}</a></td>

--- a/puppetboard/templates/nodes.html
+++ b/puppetboard/templates/nodes.html
@@ -35,7 +35,7 @@
           {% else %}
           <span>{% if node.events['failures'] %}<span class="ui small count label red">{{node.events['failures']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
             {% if node.events['successes'] %}<span class="ui small count label green">{{node.events['successes']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}</span>
-            {% if node.events['skips'] %}<span class="ui small count label yellow">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
+            {% if node.events['skips'] %}<span class="ui small count label black">{{node.events['skips']}}</span>{% else %}<span class="ui small count label">0</span>{% endif%}
           {% endif %}
       </td>
       <td><a href="{{url_for('node', node_name=node.name)}}">{{node.name}}</a></td>


### PR DESCRIPTION
"Skips" were highlighted with orange on one page and yellow on another. This change makes them consistent, and switches the color to "black" for accessibility reasons. (The contrast between the shades of orange and red used for skips and errors was *very* low. Indistinguishable on some screens.)