### PR TITLE
update query example to use certname

### DIFF
--- a/puppetboard/templates/query.html
+++ b/puppetboard/templates/query.html
@@ -14,7 +14,7 @@
   <form method="POST" action="{{ url_for('query') }}">
     {{ form.csrf_token }}
     <div class="field {% if form.query.errors %} error {% endif %}">
-      {{ form.query(autofocus="autofocus", rows=5, placeholder="Enter your query: [\"=\", \"name\", \"hostname\"]. You may omit the opening and closing bracket.") }}
+      {{ form.query(autofocus="autofocus", rows=5, placeholder="Enter your query: [\"=\", \"certname\", \"hostname\"]. You may omit the opening and closing bracket.") }}
     </div>
     <div class="inline fields">
       {% for subfield in form.endpoints %}


### PR DESCRIPTION
The query field `name` was replaced with `certname`. https://docs.puppetlabs.com/puppetdb/3.1/api/query/v4/nodes.html#query-fields

`["=", "name", "hostname"]` fails where as `["=", "certname", "hostname"]` works as expected