### PR TITLE
puppetboard/templates/layout: Removing the footer bar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -599,7 +599,7 @@ note that this group contains discussions of other Puppet Community projects.
 .. _issue: https://github.com/puppet-community/puppetboard/issues
 .. _IRCnet: http://www.ircnet.org
 .. _Freenode: http://freenode.net
-:: _GoogleGroup: https://groups.google.com/forum/?hl=en#!forum/puppet-community
+.. _GoogleGroup: https://groups.google.com/forum/?hl=en#!forum/puppet-community
 
 Third party
 ===========

--- a/README.rst
+++ b/README.rst
@@ -587,14 +587,13 @@ This project is still very new so it's not inconceivable you'll run into
 issues.
 
 For bug reports you can file an `issue`_. If you need help with something
-feel free to hit up `@daenney`_ by e-mail or find him on IRC. He can usually
-be found on `IRCnet`_ and `Freenode`_ and idles in #puppet.
+feel free to hit up the maintainers by e-mail or on IRC. They can usually
+be found on `IRCnet`_ and `Freenode`_ and idles in #puppetboard.
 
 There's now also the #puppetboard channel on `Freenode`_ where we hang out
 and answer questions related to pypuppetdb and Puppetboard.
 
-.. _issue: https://github.com/nedap/puppetboard/issues
-.. _@daenney: https://github.com/daenney
+.. _issue: https://github.com/puppet-community/puppetboard/issues
 .. _IRCnet: http://www.ircnet.org
 .. _Freenode: http://freenode.net
 

--- a/README.rst
+++ b/README.rst
@@ -593,9 +593,13 @@ be found on `IRCnet`_ and `Freenode`_ and idles in #puppetboard.
 There's now also the #puppetboard channel on `Freenode`_ where we hang out
 and answer questions related to pypuppetdb and Puppetboard.
 
+There is also a `GoogleGroup`_ to exchange questions and discussions. Please
+note that this group contains discussions of other Puppet Community projects.
+
 .. _issue: https://github.com/puppet-community/puppetboard/issues
 .. _IRCnet: http://www.ircnet.org
 .. _Freenode: http://freenode.net
+:: _GoogleGroup: https://groups.google.com/forum/?hl=en#!forum/puppet-community
 
 Third party
 ===========

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -54,12 +54,6 @@
       <i class="large arrow up icon"></i>
     </div>
 
-    <footer class="ui absolute fixed bottom">
-      <div>
-	Copyright &copy; 2013-{{ now('%Y') }} <a href="https://github.com/daenney" target="_blank">Daniele Sluijters</a>. <span style="float:right">Live from PuppetDB.</span>
-      </div>
-    </footer>
-
     {% if config.OFFLINE_MODE %}
     <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/semantic.min.js') }}"></script>

--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -54,6 +54,12 @@
       <i class="large arrow up icon"></i>
     </div>
 
+    <footer class="ui absolute fixed bottom">
+      <div>
+        Copyright &copy; 2013-{{ now('%Y') }} <a href="https://github.com/puppet-community" target="_blank">Puppet Community</a>. <span style="float:right">Live from PuppetDB.</span>
+      </div>
+    </footer>
+
     {% if config.OFFLINE_MODE %}
     <script src="{{ url_for('static', filename='js/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/semantic.min.js') }}"></script>


### PR DESCRIPTION
This bar reduces the available vertical space and other maintainers feel
it better to remove it than to modify it.

Also reducing the specific mention of @daenney from README.rst since he
has steped down as main project maintainer.