### PR TITLE
version number updated in templates/layout.html

### DIFF
--- a/puppetboard/templates/layout.html
+++ b/puppetboard/templates/layout.html
@@ -49,7 +49,7 @@
           {% endfor %}
         </div>
       </div>
-      <div class="item right"><a href="https://github.com/puppet-community/puppetboard" target="_blank">v0.1.0</a></div>
+      <div class="item right"><a href="https://github.com/puppet-community/puppetboard" target="_blank">v0.1.1</a></div>
     </div>
     <div class="ui grid padding-bottom">
       <div class="one wide column"></div>


### PR DESCRIPTION
the version of puppetboard was updated to 0.1.1 but the version number in this layout file was still 0.1.0.