### PR TITLE
puppetboard: Reloading the available environments on every page load.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Changelog
 
 This is the changelog for Puppetboard.
 
+0.1.2
+====
+
+* Add configuration option to set the default environment, defaults to
+  'production' (https://github.com/puppet-community/puppetboard/pull/185)
+* Loading all available environments with every page load. (Issue: 
+  https://github.com/puppet-community/puppetboard/issues/186)
+
+0.1.1
+====
+
+* Fix bug where the reports template was not generating the report links
+  with the right environment
+
 0.1.0
 ====
 

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -95,16 +95,19 @@ def utility_processor():
 
 @app.errorhandler(400)
 def bad_request(e):
+    envs = environments()
     return render_template('400.html', envs=envs), 400
 
 
 @app.errorhandler(403)
 def forbidden(e):
+    envs = environments()
     return render_template('403.html', envs=envs), 400
 
 
 @app.errorhandler(404)
 def not_found(e):
+    envs = environments()
     return render_template('404.html', envs=envs), 404
 
 
@@ -112,11 +115,13 @@ def not_found(e):
 def precond_failed(e):
     """We're slightly abusing 412 to handle missing features
     depending on the API version."""
+    envs = environments()
     return render_template('412.html', envs=envs), 412
 
 
 @app.errorhandler(500)
 def server_error(e):
+    envs = environments()
     return render_template('500.html', envs=envs), 500
 
 

--- a/puppetboard/app.py
+++ b/puppetboard/app.py
@@ -78,14 +78,12 @@ def environments():
 
     return x
 
-def check_env(env):
+def check_env(env, envs):
     if env != '*' and env not in envs:
         abort(404)
 
 app.jinja_env.globals['url_for_pagination'] = url_for_pagination
 app.jinja_env.globals['url_for_environments'] = url_for_environments
-
-envs = environments()
 
 @app.context_processor
 def utility_processor():
@@ -131,7 +129,8 @@ def index(env):
     :param env: Search for nodes in this (Catalog and Fact) environment
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     # TODO: Would be great if we could parallelize this somehow, doing these
     # requests in sequence is rather pointless.
@@ -212,7 +211,8 @@ def nodes(env):
     :param env: Search for nodes in this (Catalog and Fact) environment
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         query = None
@@ -255,7 +255,8 @@ def inventory(env):
     :param env: Search for facts in this environment
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     fact_desc  = []     # a list of fact descriptions to go
                         # in the table header
@@ -327,7 +328,8 @@ def node(env, node_name):
     :param env: Ensure that the node, facts and reports are in this environment
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         query = '["=", "certname", "{0}"]]'.format(node_name)
@@ -380,7 +382,8 @@ def reports(env, page):
         and this value
     :type page: :obj:`int`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         reports_query = None
@@ -444,7 +447,8 @@ def reports_node(env, node_name, page):
         and this value
     :type page: :obj:`int`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         query = '["=", "certname", "{0}"]]'.format(node_name)
@@ -502,7 +506,8 @@ def report_latest(env, node_name):
     :param node_name: Find the reports whose certname match this value
     :type node_name: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         query='["and",' \
@@ -544,7 +549,8 @@ def report(env, node_name, report_id):
         report
     :type report_id: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         query = '["and", ["=", "certname", "{0}"],' \
@@ -581,7 +587,8 @@ def facts(env):
         sake
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     facts_dict = collections.defaultdict(list)
     facts = get_or_abort(puppetdb.fact_names)
@@ -609,7 +616,8 @@ def fact(env, fact):
     :param fact: Find all facts with this name
     :type fact: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     # we can only consume the generator once, lists can be doubly consumed
     # om nom nom
@@ -643,7 +651,8 @@ def fact_value(env, fact, value):
     :param value: Filter facts whose value is equal to this
     :type value: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if env == '*':
         query = None
@@ -676,7 +685,8 @@ def query(env):
         select field in the environment block
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if app.config['ENABLE_QUERY']:
         form = QueryForm()
@@ -712,7 +722,8 @@ def metrics(env):
         for the environments template block
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     metrics = get_or_abort(puppetdb._query, 'mbean')
     for key, value in metrics.items():
@@ -732,7 +743,8 @@ def metric(env, metric):
         for the environments template block
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     name = unquote(metric)
     metric = puppetdb.metric(metric)
@@ -751,7 +763,8 @@ def catalogs(env):
     :param env: Find the nodes with this catalog_environment value
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if app.config['ENABLE_CATALOG']:
         nodenames = []
@@ -806,7 +819,8 @@ def catalog_node(env, node_name):
     :param env: Find the catalog with this environment value
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if app.config['ENABLE_CATALOG']:
         catalog = get_or_abort(puppetdb.catalog,
@@ -831,7 +845,8 @@ def catalog_submit(env):
        catalogs page with the right environment.
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if app.config['ENABLE_CATALOG']:
         form = CatalogForm(request.form)
@@ -859,7 +874,8 @@ def catalog_compare(env, compare, against):
     :param env: Ensure that the 2 catalogs are in the same environment
     :type env: :obj:`string`
     """
-    check_env(env)
+    envs = environments()
+    check_env(env, envs)
 
     if app.config['ENABLE_CATALOG']:
         compare_cat = get_or_abort(puppetdb.catalog,


### PR DESCRIPTION
Moving the global environment list from a global context to a functional
context because octomike reported that the environment list in his environment
was not being refreshed. Fixes https://github.com/puppet-community/puppetboard/issues/186

Adding CHANGELOG entries for 0.1.1 and this new change.